### PR TITLE
UPDATE remove versioned truncator module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "axllent/silverstripe-version-truncator": "^3",
         "dynamic/silverstripe-base-site": "^6",
         "dynamic/silverstripe-carousel": "^1.0",
         "innoweb/silverstripe-googleanalytics": "^5.0",


### PR DESCRIPTION
This module limits the number of history records in the CMS and should be added per project vs added at installation.