### PR TITLE
feat: Silverstripe CMS 6 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,17 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "dynamic/silverstripe-base-site": "^7",
-        "dynamic/silverstripe-carousel": "^2.0",
+        "php": "^8.3",
+        "dynamic/silverstripe-base-site": "^8",
+        "dynamic/silverstripe-carousel": "^3.0",
         "innoweb/silverstripe-googleanalytics": "^5.0",
-        "innoweb/silverstripe-social-metadata": "^8.2",
-        "innoweb/silverstripe-social-share": "^4.0",
-        "silverstripe/blog": "^4",
-        "silverstripe/redirectedurls": "^3",
+        "innoweb/silverstripe-social-metadata": "^9.0",
+        "innoweb/silverstripe-social-share": "^5.0",
+        "silverstripe/blog": "^5",
+        "silverstripe/redirectedurls": "^4",
         "silverstripe/securityreport": "^3",
-        "silverstripe/spamprotection": "^4",
-        "silverstripe/userforms": "^6",
-        "silverstripe/widgets": "^3"
+        "silverstripe/spamprotection": "^5",
+        "silverstripe/userforms": "^7"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^3"


### PR DESCRIPTION
## Summary
Upgrade recipe to support Silverstripe CMS 6.

## Breaking Changes
- **PHP 8.3+** required (`^8.1` → `^8.3`)
- **Silverstripe CMS 6** via `base-site ^8` → `recipe-cms ^6`
- **Removed `silverstripe/widgets`** — no SS6-compatible release available

## Dependency Changes

| Package | Old | New |
|---------|-----|-----|
| `php` | `^8.1` | `^8.3` |
| `dynamic/silverstripe-base-site` | `^7` | `^8` |
| `dynamic/silverstripe-carousel` | `^2` | `^3` |
| `innoweb/silverstripe-social-metadata` | `^8.2` | `^9.0` |
| `innoweb/silverstripe-social-share` | `^4` | `^5` |
| `silverstripe/blog` | `^4` | `^5` |
| `silverstripe/redirectedurls` | `^3` | `^4` |
| `silverstripe/spamprotection` | `^4` | `^5` |
| `silverstripe/userforms` | `^6` | `^7` |
| `silverstripe/widgets` | `^3` | **removed** |