### PR TITLE
fix: drop securityreport (no SS6 version)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "innoweb/silverstripe-social-share": "^5.0",
         "silverstripe/blog": "^5",
         "silverstripe/redirectedurls": "^4",
-        "silverstripe/securityreport": "^3",
         "silverstripe/spamprotection": "^5",
         "silverstripe/userforms": "^7"
     },


### PR DESCRIPTION
securityreport ^3 requires reports ^5 → vendor-plugin ^2, conflicting with SS6's vendor-plugin ^3.