### PR TITLE
fix: drop googleanalytics (no SS6 version)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "php": "^8.3",
         "dynamic/silverstripe-base-site": "^8",
         "dynamic/silverstripe-carousel": "^3.0",
-        "innoweb/silverstripe-googleanalytics": "^5.0",
         "innoweb/silverstripe-social-metadata": "^9.0",
         "innoweb/silverstripe-social-share": "^5.0",
         "silverstripe/blog": "^5",


### PR DESCRIPTION
innoweb/silverstripe-googleanalytics ^5.0 requires framework ^5, incompatible with SS6.